### PR TITLE
add 'sudo mv' as fallback

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,7 +105,7 @@ function install {
 	fi
 	#move into PATH or cwd
 	chmod +x $TMP_BIN || fail "chmod +x failed"
-	mv $TMP_BIN $OUT_DIR/$PROG || fail "mv failed" #FINAL STEP!
+	mv $TMP_BIN $OUT_DIR/$PROG || sudo mv $TMP_BIN $OUT_DIR/$PROG || fail "mv failed" #FINAL STEP!
 	echo "{{ if .MoveToPath }}Installed at{{ else }}Downloaded to{{ end }} $OUT_DIR/$PROG"
 	#done
 	cleanup


### PR DESCRIPTION
when i run install.sh as user, then
mv $TMP_BIN $OUT_DIR/$PROG
fails with
Permission denied
with OUT_DIR="/usr/local/bin"

now, if mv fails, fall back to 'sudo mv'

to fix issue https://github.com/jpillora/cloud-torrent/issues/270 
