### PR TITLE
Change out_dir on m1 macbook

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,6 +52,9 @@ function install {
 		ARCH="amd64"
 	elif uname -m | grep arm > /dev/null; then
 		ARCH="arm" #TODO armv6/v7
+		if OS == "Darwin"; then
+			OUT_DIR='/bin'
+		fi
 	elif uname -m | grep 386 > /dev/null; then
 		ARCH="386"
 	else


### PR DESCRIPTION
Add support for /usr/local/bin migration to /bin on m1 macbook air

Fixes Issue #20 