### PR TITLE
Use specific arch and forgo defaults

### DIFF
--- a/handler/strings.go
+++ b/handler/strings.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	archRe     = regexp.MustCompile(`(arm64|arm|386|amd64|x86_64|aarch64|32|64)`)
+	archRe     = regexp.MustCompile(`(arm64|arm|386|amd64|x86_64|aarch64|i686)`)
 	fileExtRe  = regexp.MustCompile(`(\.[a-z][a-z0-9]+)+$`)
 	posixOSRe  = regexp.MustCompile(`(darwin|linux|(net|free|open)bsd|mac|osx|windows|win)`)
 	checksumRe = regexp.MustCompile(`(checksums|sha256sums)`)
@@ -28,9 +28,9 @@ func getArch(s string) string {
 	s = strings.ToLower(s)
 	a := archRe.FindString(s)
 	//arch modifications
-	if a == "64" || a == "x86_64" || a == "" {
-		a = "amd64" //default
-	} else if a == "32" {
+	if a == "x86_64" || a == "" {
+		a = "amd64"
+	} else if a == "i686" {
 		a = "386"
 	} else if a == "aarch64" {
 		a = "arm64"


### PR DESCRIPTION
The default idea doesn't really work as it pick the first assed matching, not the best one. ppc64 and ppc32 would break the heuristic based on ordering.

There may be a better way. Also, not tested.. 