### PR TITLE
Feature/multiple-binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ curl https://i.jpillora.com/<query>! | bash
     * `type=homebrew` is **not** working at the moment – see [Homebrew](#homebrew)
 * `?insecure=1` Force `curl`/`wget` to skip certificate checks
 * `?as=` Force the binary to be named as this parameter value
-* `?bin=` Binary name, if **repository name** and **binary name** in release differs.
-    * **eg**: repo_name is **foobar** and binary name is **fb** in release then `?bin=fb`.
+* `?select=` Select binary, if **repository name** and **binary name** in release differs.
+    * **eg**: repo_name is **foobar** and binary name is **fb-client** and **fb-server** in release, Then `?select=fb-client` & `?select=fb-server` accordingly.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ curl https://i.jpillora.com/<query>! | bash
     * `type=homebrew` is **not** working at the moment – see [Homebrew](#homebrew)
 * `?insecure=1` Force `curl`/`wget` to skip certificate checks
 * `?as=` Force the binary to be named as this parameter value
-* `?bin=` Binary name, if `repository name` and `binary name` in release differs.
-    * **eg:**: repo_name is **foobar** and binary name is **fb** in release then `?bin=fb`.
+* `?bin=` Binary name, if **repository name** and **binary name** in release differs.
+    * **eg**: repo_name is **foobar** and binary name is **fb** in release then `?bin=fb`.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ curl https://i.jpillora.com/<query>! | bash
     * `type=homebrew` is **not** working at the moment – see [Homebrew](#homebrew)
 * `?insecure=1` Force `curl`/`wget` to skip certificate checks
 * `?as=` Force the binary to be named as this parameter value
+* `?bin=` Binary name, if `repository name` and `binary name` in release differs.
+    * **eg:**: repo_name is **foobar** and binary name is **fb** in release then `?bin=fb`.
 
 ## Security
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -31,9 +31,9 @@ var (
 )
 
 type Query struct {
-	User, Program, AsProgram, Release string
-	MoveToPath, Search, Insecure      bool
-	SudoMove                          bool // deprecated: not used, now automatically detected
+	User, Program, AsProgram, BinaryName, Release string
+	MoveToPath, Search, Insecure                  bool
+	SudoMove                                      bool // deprecated: not used, now automatically detected
 }
 
 type Result struct {
@@ -107,11 +107,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	q := Query{
-		User:      "",
-		Program:   "",
-		Release:   "",
-		Insecure:  r.URL.Query().Get("insecure") == "1",
-		AsProgram: r.URL.Query().Get("as"),
+		User:       "",
+		Program:    "",
+		Release:    "",
+		BinaryName: r.URL.Query().Get("bin"),
+		Insecure:   r.URL.Query().Get("insecure") == "1",
+		AsProgram:  r.URL.Query().Get("as"),
 	}
 	// set query from route
 	path := strings.TrimPrefix(r.URL.Path, "/")
@@ -124,6 +125,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	q.User, rest = splitHalf(path, "/")
 	q.Program, q.Release = splitHalf(rest, "@")
 	// no program? treat first part as program, use default user
+
+	if q.AsProgram == "" && q.BinaryName != "" {
+		q.AsProgram = q.BinaryName
+	}
+
 	if q.Program == "" {
 		q.Program = q.User
 		q.User = h.Config.User

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -31,9 +31,9 @@ var (
 )
 
 type Query struct {
-	User, Program, AsProgram, BinaryName, Release string
-	MoveToPath, Search, Insecure                  bool
-	SudoMove                                      bool // deprecated: not used, now automatically detected
+	User, Program, AsProgram, Selected, Release string
+	MoveToPath, Search, Insecure                bool
+	SudoMove                                    bool // deprecated: not used, now automatically detected
 }
 
 type Result struct {
@@ -107,12 +107,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	q := Query{
-		User:       "",
-		Program:    "",
-		Release:    "",
-		BinaryName: r.URL.Query().Get("bin"),
-		Insecure:   r.URL.Query().Get("insecure") == "1",
-		AsProgram:  r.URL.Query().Get("as"),
+		User:      "",
+		Program:   "",
+		Release:   "",
+		Selected:  r.URL.Query().Get("select"),
+		Insecure:  r.URL.Query().Get("insecure") == "1",
+		AsProgram: r.URL.Query().Get("as"),
 	}
 	// set query from route
 	path := strings.TrimPrefix(r.URL.Path, "/")
@@ -126,8 +126,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	q.Program, q.Release = splitHalf(rest, "@")
 	// no program? treat first part as program, use default user
 
-	if q.AsProgram == "" && q.BinaryName != "" {
-		q.AsProgram = q.BinaryName
+	if q.AsProgram == "" && q.Selected != "" {
+		q.AsProgram = q.Selected
 	}
 
 	if q.Program == "" {

--- a/handler/handler_execute.go
+++ b/handler/handler_execute.go
@@ -118,9 +118,9 @@ func (h *Handler) getAssetsNoCache(q Query) (string, Assets, error) {
 		//TODO deb,rpm etc
 		fext := getFileExt(url)
 
-		if q.BinaryName != "" {
+		if q.Selected != "" {
 			//filter binary with it's name
-			if !strings.Contains(ga.Name[0:len(q.BinaryName)+1], fmt.Sprint(q.BinaryName, "-")) {
+			if !strings.Contains(ga.Name[0:len(q.Selected)+1], fmt.Sprint(q.Selected, "-")) {
 				continue
 			}
 		}

--- a/handler/handler_execute.go
+++ b/handler/handler_execute.go
@@ -119,7 +119,7 @@ func (h *Handler) getAssetsNoCache(q Query) (string, Assets, error) {
 		fext := getFileExt(url)
 
 		if q.BinaryName != "" {
-			//filter by binary with it's name
+			//filter binary with it's name
 			if !strings.Contains(ga.Name[0:len(q.BinaryName)+1], fmt.Sprint(q.BinaryName, "-")) {
 				continue
 			}

--- a/handler/handler_execute.go
+++ b/handler/handler_execute.go
@@ -120,7 +120,7 @@ func (h *Handler) getAssetsNoCache(q Query) (string, Assets, error) {
 
 		if q.Selected != "" {
 			//filter binary with it's name
-			if !strings.Contains(ga.Name[0:len(q.Selected)+1], fmt.Sprint(q.Selected, "-")) {
+			if len(ga.Name) > len(q.Selected)+1 && !strings.Contains(ga.Name[0:len(q.Selected)+1], fmt.Sprint(q.Selected, "-")) {
 				continue
 			}
 		}

--- a/handler/handler_execute.go
+++ b/handler/handler_execute.go
@@ -117,6 +117,14 @@ func (h *Handler) getAssetsNoCache(q Query) (string, Assets, error) {
 		//only binary containers are supported
 		//TODO deb,rpm etc
 		fext := getFileExt(url)
+
+		if q.BinaryName != "" {
+			//filter by binary with it's name
+			if !strings.Contains(ga.Name[0:len(q.BinaryName)+1], fmt.Sprint(q.BinaryName, "-")) {
+				continue
+			}
+		}
+
 		if fext == "" && ga.Size > 1024*1024 {
 			fext = ".bin" // +1MB binary
 		}

--- a/scripts/install.sh.tmpl
+++ b/scripts/install.sh.tmpl
@@ -17,6 +17,7 @@ function install {
 	#settings
 	USER="{{ .User }}"
 	PROG="{{ .Program }}"
+	BIN_NAME="{{ .BinaryName }}"
 	ASPROG="{{ .AsProgram }}"
 	MOVE="{{ .MoveToPath }}"
 	RELEASE="{{ .Release }}"
@@ -93,6 +94,9 @@ function install {
 	#got URL! download it...
 	echo -n "{{ if .MoveToPath }}Installing{{ else }}Downloading{{ end }}"
 	echo -n " $USER/$PROG"
+	if [ ! -z "$BIN_NAME" ]; then
+		echo -n "/$BIN_NAME"
+	fi
 	if [ ! -z "$RELEASE" ]; then
 		echo -n " $RELEASE"
 	fi

--- a/scripts/install.sh.tmpl
+++ b/scripts/install.sh.tmpl
@@ -17,7 +17,7 @@ function install {
 	#settings
 	USER="{{ .User }}"
 	PROG="{{ .Program }}"
-	BIN_NAME="{{ .BinaryName }}"
+	SEL_BIN="{{ .Selected }}"
 	ASPROG="{{ .AsProgram }}"
 	MOVE="{{ .MoveToPath }}"
 	RELEASE="{{ .Release }}"
@@ -94,8 +94,8 @@ function install {
 	#got URL! download it...
 	echo -n "{{ if .MoveToPath }}Installing{{ else }}Downloading{{ end }}"
 	echo -n " $USER/$PROG"
-	if [ ! -z "$BIN_NAME" ]; then
-		echo -n "/$BIN_NAME"
+	if [ ! -z "$SEL_BIN" ]; then
+		echo -n "/$SEL_BIN"
 	fi
 	if [ ! -z "$RELEASE" ]; then
 		echo -n " $RELEASE"

--- a/scripts/install.txt.tmpl
+++ b/scripts/install.txt.tmpl
@@ -1,7 +1,7 @@
 repository: https://github.com/{{ .User }}/{{ .Program }}
 user: {{ .User }}
 program: {{ .Program }}{{if .Selected }}
-binary-name: {{.Selected}}{{end}}{{if .AsProgram }}
+selected-binary: {{.Selected}}{{end}}{{if .AsProgram }}
 as: {{ .AsProgram }}{{end}}
 release: {{ .Release }}
 move-into-path: {{ .MoveToPath }}

--- a/scripts/install.txt.tmpl
+++ b/scripts/install.txt.tmpl
@@ -1,7 +1,7 @@
 repository: https://github.com/{{ .User }}/{{ .Program }}
 user: {{ .User }}
-program: {{ .Program }}{{if .AsProgram }}
-binary-name: {{.BinaryName}}
+program: {{ .Program }}{{if .BinaryName }}
+binary-name: {{.BinaryName}}{{end}}{{if .AsProgram }}
 as: {{ .AsProgram }}{{end}}
 release: {{ .Release }}
 move-into-path: {{ .MoveToPath }}

--- a/scripts/install.txt.tmpl
+++ b/scripts/install.txt.tmpl
@@ -1,6 +1,7 @@
 repository: https://github.com/{{ .User }}/{{ .Program }}
 user: {{ .User }}
 program: {{ .Program }}{{if .AsProgram }}
+binary-name: {{.BinaryName}}
 as: {{ .AsProgram }}{{end}}
 release: {{ .Release }}
 move-into-path: {{ .MoveToPath }}

--- a/scripts/install.txt.tmpl
+++ b/scripts/install.txt.tmpl
@@ -1,7 +1,7 @@
 repository: https://github.com/{{ .User }}/{{ .Program }}
 user: {{ .User }}
-program: {{ .Program }}{{if .BinaryName }}
-binary-name: {{.BinaryName}}{{end}}{{if .AsProgram }}
+program: {{ .Program }}{{if .Selected }}
+binary-name: {{.Selected}}{{end}}{{if .AsProgram }}
 as: {{ .AsProgram }}{{end}}
 release: {{ .Release }}
 move-into-path: {{ .MoveToPath }}


### PR DESCRIPTION

# Added Support for Binary Name via Query Params

### Issue:
When a repository name differs from its binary release name, it could previously not be handled correctly. For example, if the **repository name** is `foobar` but the binary name is `fb`.

### Solution:
To address this issue, the parameter `?bin=` has been introduced. This allows for the specification of the binary name directly in the query parameters.

### Behavior of Changes:
These changes do not affect any previous functionality. The addition of the `bin` parameter serves as an enhancement, allowing users who need to specify a different binary name to do so. This ensures compatibility and flexibility for various repository and binary naming conventions.
